### PR TITLE
fix: lazy-import PCAAggregator so base install works without ML extras

### DIFF
--- a/src/unbubble_sources/config/factory.py
+++ b/src/unbubble_sources/config/factory.py
@@ -1,9 +1,14 @@
 """Factory functions to create components from configuration."""
 
+from __future__ import annotations
+
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from unbubble_sources.aggregator.pca import PCAAggregator
 
 from unbubble_sources.aggregator.noop import NoOpAggregator
-from unbubble_sources.aggregator.pca import PCAAggregator
 from unbubble_sources.annotator.claude import ClaudeAnnotator
 from unbubble_sources.config.models import (
     ClaudeAnnotatorConfig,
@@ -93,6 +98,8 @@ def create_aggregator(
 ) -> PCAAggregator | NoOpAggregator:
     """Create a query aggregator from config."""
     if isinstance(config, PCAAggregatorConfig):
+        from unbubble_sources.aggregator.pca import PCAAggregator
+
         return PCAAggregator(
             n_components=config.n_components,
             sentence_transformer_model=config.sentence_transformer_model,


### PR DESCRIPTION
## Summary

- PR #21 made ML dependencies optional under `[ml]` extras, but `factory.py` still imports `PCAAggregator` at module level
- This causes `ModuleNotFoundError: No module named 'numpy'` on any import from `unbubble_sources` without ML extras installed
- Moves the import into `create_aggregator()` so it only runs when PCA is actually requested
- Uses `TYPE_CHECKING` to keep the type annotation without a runtime import

## Test plan

- [x] `uv sync && uv run python -c "from unbubble_sources.config import create_from_config"` succeeds without ML extras
- [x] `uv sync --extra ml && uv run python -c "from unbubble_sources.aggregator.pca import PCAAggregator"` still works
- [x] `uv run pytest -v` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)