### PR TITLE
Replace published_at string with datetime timestamp

### DIFF
--- a/livedemo/api/run.py
+++ b/livedemo/api/run.py
@@ -11,8 +11,8 @@ import json
 import os
 import queue
 import threading
-from http.server import BaseHTTPRequestHandler
 from datetime import datetime
+from http.server import BaseHTTPRequestHandler
 from typing import Any
 
 # unbubble_sources is installed from the repo root via requirements.txt

--- a/livedemo/api/run.py
+++ b/livedemo/api/run.py
@@ -13,6 +13,7 @@ import queue
 import threading
 from http.server import BaseHTTPRequestHandler
 from datetime import datetime
+from typing import Any
 
 # unbubble_sources is installed from the repo root via requirements.txt
 from unbubble_sources.config import load_config
@@ -20,7 +21,7 @@ from unbubble_sources.data import NewsEvent
 from unbubble_sources.stream_logger import StreamLogger
 
 
-def _json_default(obj: object) -> str:
+def _json_default(obj: Any) -> str:
     if isinstance(obj, datetime):
         return obj.isoformat()
     return str(obj)

--- a/livedemo/api/run.py
+++ b/livedemo/api/run.py
@@ -12,11 +12,18 @@ import os
 import queue
 import threading
 from http.server import BaseHTTPRequestHandler
+from datetime import datetime
 
 # unbubble_sources is installed from the repo root via requirements.txt
 from unbubble_sources.config import load_config
 from unbubble_sources.data import NewsEvent
 from unbubble_sources.stream_logger import StreamLogger
+
+
+def _json_default(obj: object) -> str:
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    return str(obj)
 
 
 def _find_config() -> str:
@@ -86,7 +93,7 @@ class handler(BaseHTTPRequestHandler):  # noqa: N801 — Vercel requires lowerca
             item = q.get()
             if item is None:
                 break
-            self.wfile.write((json.dumps(item, default=str) + "\n").encode())
+            self.wfile.write((json.dumps(item, default=_json_default) + "\n").encode())
             self.wfile.flush()
 
         thread.join()

--- a/main.py
+++ b/main.py
@@ -74,14 +74,14 @@ async def run(args: CLIArgs) -> None:
             logger.info(f"   Source: {inner.source}")
             logger.info(f"   URL: {inner.url}")
             if inner.published_at:
-                logger.info(f"   Published: {inner.published_at}")
+                logger.info(f"   Published: {inner.published_at.isoformat()}")
         elif isinstance(inner, Tweet):
             text_preview = inner.text[:100] + ("..." if len(inner.text) > 100 else "")
             logger.info(f"{i}. @{inner.author_handle}: {text_preview}")
             logger.info(f"   URL: {inner.url}")
             logger.info(f"   Likes: {inner.like_count} | Retweets: {inner.retweet_count}")
             if inner.published_at:
-                logger.info(f"   Published: {inner.published_at}")
+                logger.info(f"   Published: {inner.published_at.isoformat()}")
         else:
             logger.info(f"{i}. {inner.url}")
             logger.info(f"   Source: {inner.source}")

--- a/src/unbubble_sources/annotator/claude.py
+++ b/src/unbubble_sources/annotator/claude.py
@@ -79,7 +79,7 @@ def _source_to_prompt_text(source: Source, index: int) -> str:
     parts.append(f"  URL: {source.url}")
     parts.append(f"  Publisher: {source.source}")
     if source.published_at:
-        parts.append(f"  Published: {source.published_at}")
+        parts.append(f"  Published: {source.published_at.isoformat()}")
     if isinstance(source, Article):
         if source.title:
             parts.append(f"  Title: {source.title}")

--- a/src/unbubble_sources/data/models.py
+++ b/src/unbubble_sources/data/models.py
@@ -1,8 +1,8 @@
 """Core data models for Unbubble."""
 
 from dataclasses import dataclass, field
-from enum import StrEnum
 from datetime import datetime
+from enum import StrEnum
 
 
 class PolicyFrame(StrEnum):

--- a/src/unbubble_sources/data/models.py
+++ b/src/unbubble_sources/data/models.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import StrEnum
+from datetime import datetime
 
 
 class PolicyFrame(StrEnum):
@@ -85,7 +86,7 @@ class Source:
 
     url: str
     source: str
-    published_at: str | None = None
+    published_at: datetime | None = None
     query: SearchQuery | None = None
 
 

--- a/src/unbubble_sources/parsers.py
+++ b/src/unbubble_sources/parsers.py
@@ -1,0 +1,13 @@
+"""Parsing utilities for normalizing raw API values."""
+
+from datetime import datetime
+
+
+def parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    

--- a/src/unbubble_sources/parsers.py
+++ b/src/unbubble_sources/parsers.py
@@ -3,11 +3,9 @@
 from datetime import datetime
 
 
-def parse_datetime(value: str | None) -> datetime | None:
-    if not value:
-        return None
+def maybe_parse_datetime(value: str) -> datetime | None:
+    """Attempt parsing the input string into a datetime object, returns None if it is not a date in the correct format."""
     try:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError:
         return None
-    

--- a/src/unbubble_sources/pipeline/claude_e2e.py
+++ b/src/unbubble_sources/pipeline/claude_e2e.py
@@ -170,7 +170,7 @@ the same underlying facts but from genuinely different angles.\
                                 title=result.title or "",
                                 url=result.url,
                                 source=extract_domain(result.url),
-                                published_at=result.page_age,
+                                published_at=None,
                                 description=None,
                                 query=dummy_query,
                             )

--- a/src/unbubble_sources/search/claude.py
+++ b/src/unbubble_sources/search/claude.py
@@ -162,7 +162,7 @@ class ClaudeSearcher:
             title=result.title,
             url=result.url,
             source=extract_domain(result.url),
-            published_at=result.page_age,
+            published_at=None,
             description=None,  # encrypted_content is not human-readable
             query=query,
         )

--- a/src/unbubble_sources/search/exa.py
+++ b/src/unbubble_sources/search/exa.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 from urllib.parse import urlparse
+from datetime import datetime
 
 from exa_py import AsyncExa
 
@@ -109,7 +110,7 @@ class ExaSearcher:
                     url=result.url,
                     source=domain,
                     title=result.title or "",
-                    published_at=result.published_date,
+                    published_at=_parse_datetime(result.published_date),
                     query=query,
                 )
             )
@@ -137,3 +138,12 @@ def _extract_domain(url: str) -> str:
         return hostname
     except Exception:
         return "unknown"
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/src/unbubble_sources/search/exa.py
+++ b/src/unbubble_sources/search/exa.py
@@ -4,12 +4,11 @@ import asyncio
 import logging
 import os
 from urllib.parse import urlparse
-from datetime import datetime
 
 from exa_py import AsyncExa
 
 from unbubble_sources.data import Article, SearchQuery, Source, Usage
-from unbubble_sources.parsers import parse_datetime
+from unbubble_sources.parsers import maybe_parse_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -106,12 +105,13 @@ class ExaSearcher:
         articles: list[Article] = []
         for result in response.results:
             domain = _extract_domain(result.url)
+            raw_date = result.published_date
             articles.append(
                 Article(
                     url=result.url,
                     source=domain,
                     title=result.title or "",
-                    published_at=parse_datetime(result.published_date),
+                    published_at=maybe_parse_datetime(raw_date) if raw_date else None,
                     query=query,
                 )
             )
@@ -139,4 +139,3 @@ def _extract_domain(url: str) -> str:
         return hostname
     except Exception:
         return "unknown"
-    

--- a/src/unbubble_sources/search/exa.py
+++ b/src/unbubble_sources/search/exa.py
@@ -9,6 +9,7 @@ from datetime import datetime
 from exa_py import AsyncExa
 
 from unbubble_sources.data import Article, SearchQuery, Source, Usage
+from unbubble_sources.parsers import parse_datetime
 
 logger = logging.getLogger(__name__)
 
@@ -110,7 +111,7 @@ class ExaSearcher:
                     url=result.url,
                     source=domain,
                     title=result.title or "",
-                    published_at=_parse_datetime(result.published_date),
+                    published_at=parse_datetime(result.published_date),
                     query=query,
                 )
             )
@@ -138,12 +139,4 @@ def _extract_domain(url: str) -> str:
         return hostname
     except Exception:
         return "unknown"
-
-
-def _parse_datetime(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
+    

--- a/src/unbubble_sources/search/gnews.py
+++ b/src/unbubble_sources/search/gnews.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+from datetime import datetime
 
 import httpx
 
@@ -114,9 +115,18 @@ class GNewsSearcher:
                     title=item.get("title", ""),
                     url=item.get("url", ""),
                     source=item.get("source", {}).get("name", "Unknown"),
-                    published_at=item.get("publishedAt"),
+                    published_at=_parse_datetime(item.get("publishedAt")),
                     description=item.get("description"),
                     query=query,
                 )
             )
         return articles
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/src/unbubble_sources/search/gnews.py
+++ b/src/unbubble_sources/search/gnews.py
@@ -5,7 +5,7 @@ import os
 import httpx
 
 from unbubble_sources.data import Article, SearchQuery, Source, Usage
-from unbubble_sources.parsers import parse_datetime
+from unbubble_sources.parsers import maybe_parse_datetime
 
 GNEWS_API_URL = "https://gnews.io/api/v4/search"
 
@@ -110,15 +110,15 @@ class GNewsSearcher:
 
         articles: list[Article] = []
         for item in data.get("articles", []):
+            raw_date = item.get("publishedAt")
             articles.append(
                 Article(
                     title=item.get("title", ""),
                     url=item.get("url", ""),
                     source=item.get("source", {}).get("name", "Unknown"),
-                    published_at=parse_datetime(item.get("publishedAt")),
+                    published_at=maybe_parse_datetime(raw_date) if raw_date else None,
                     description=item.get("description"),
                     query=query,
                 )
             )
         return articles
-    

--- a/src/unbubble_sources/search/gnews.py
+++ b/src/unbubble_sources/search/gnews.py
@@ -1,11 +1,11 @@
 import asyncio
 import logging
 import os
-from datetime import datetime
 
 import httpx
 
 from unbubble_sources.data import Article, SearchQuery, Source, Usage
+from unbubble_sources.parsers import parse_datetime
 
 GNEWS_API_URL = "https://gnews.io/api/v4/search"
 
@@ -115,18 +115,10 @@ class GNewsSearcher:
                     title=item.get("title", ""),
                     url=item.get("url", ""),
                     source=item.get("source", {}).get("name", "Unknown"),
-                    published_at=_parse_datetime(item.get("publishedAt")),
+                    published_at=parse_datetime(item.get("publishedAt")),
                     description=item.get("description"),
                     query=query,
                 )
             )
         return articles
-
-
-def _parse_datetime(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None
+    

--- a/src/unbubble_sources/search/grok.py
+++ b/src/unbubble_sources/search/grok.py
@@ -16,8 +16,8 @@ import os
 import httpx
 
 from unbubble_sources.data import APICallUsage, SearchQuery, Source, Tweet, Usage
+from unbubble_sources.parsers import maybe_parse_datetime
 from unbubble_sources.url import extract_domain
-from unbubble_sources.parsers import parse_datetime
 
 GROK_RESPONSES_URL = "https://api.x.ai/v1/responses"
 DEFAULT_MODEL = "grok-4-1-fast"
@@ -248,11 +248,12 @@ class GrokSearcher:
             if not url:
                 continue
             author_handle = str(item.get("author_handle", "")).strip()
+            raw_date = item.get("published_at")
             tweets.append(
                 Tweet(
                     url=url,
                     source=extract_domain(url) or "x.com",
-                    published_at=parse_datetime(item.get("published_at")),
+                    published_at=maybe_parse_datetime(raw_date) if raw_date else None,
                     query=query,
                     tweet_id=_extract_tweet_id(url),
                     author_handle=author_handle,

--- a/src/unbubble_sources/search/grok.py
+++ b/src/unbubble_sources/search/grok.py
@@ -12,12 +12,12 @@ import asyncio
 import json
 import logging
 import os
-from datetime import datetime
 
 import httpx
 
 from unbubble_sources.data import APICallUsage, SearchQuery, Source, Tweet, Usage
 from unbubble_sources.url import extract_domain
+from unbubble_sources.parsers import parse_datetime
 
 GROK_RESPONSES_URL = "https://api.x.ai/v1/responses"
 DEFAULT_MODEL = "grok-4-1-fast"
@@ -252,7 +252,7 @@ class GrokSearcher:
                 Tweet(
                     url=url,
                     source=extract_domain(url) or "x.com",
-                    published_at=_parse_datetime(item.get("published_at")),
+                    published_at=parse_datetime(item.get("published_at")),
                     query=query,
                     tweet_id=_extract_tweet_id(url),
                     author_handle=author_handle,
@@ -276,12 +276,3 @@ def _extract_tweet_id(url: str) -> str:
     if len(parts) >= 2 and parts[-2] == "status":
         return parts[-1]
     return ""
-
-
-def _parse_datetime(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None

--- a/src/unbubble_sources/search/grok.py
+++ b/src/unbubble_sources/search/grok.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import logging
 import os
+from datetime import datetime
 
 import httpx
 
@@ -251,7 +252,7 @@ class GrokSearcher:
                 Tweet(
                     url=url,
                     source=extract_domain(url) or "x.com",
-                    published_at=item.get("published_at") or None,
+                    published_at=_parse_datetime(item.get("published_at")),
                     query=query,
                     tweet_id=_extract_tweet_id(url),
                     author_handle=author_handle,
@@ -275,3 +276,12 @@ def _extract_tweet_id(url: str) -> str:
     if len(parts) >= 2 and parts[-2] == "status":
         return parts[-1]
     return ""
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/src/unbubble_sources/search/x.py
+++ b/src/unbubble_sources/search/x.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+from datetime import datetime
 
 import httpx
 
@@ -134,7 +135,7 @@ class XSearcher:
                 Tweet(
                     url=f"https://x.com/{author_handle}/status/{tweet_id}",
                     source="x.com",
-                    published_at=item.get("created_at"),
+                    published_at=_parse_datetime(item.get("created_at")),
                     query=query,
                     tweet_id=tweet_id,
                     author_handle=author_handle,
@@ -157,3 +158,12 @@ def _to_rfc3339(date_str: str) -> str:
     if "T" in date_str:
         return date_str
     return f"{date_str}T00:00:00Z"
+
+
+def _parse_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None

--- a/src/unbubble_sources/search/x.py
+++ b/src/unbubble_sources/search/x.py
@@ -3,12 +3,11 @@
 import asyncio
 import logging
 import os
-from datetime import datetime
 
 import httpx
 
 from unbubble_sources.data import SearchQuery, Source, Tweet, Usage
-from unbubble_sources.parsers import parse_datetime
+from unbubble_sources.parsers import maybe_parse_datetime
 
 X_API_URL = "https://api.twitter.com/2/tweets/search/recent"
 
@@ -131,12 +130,13 @@ class XSearcher:
             author_info = authors.get(author_id, {})
             author_handle = author_info.get("username", "")
             metrics = item.get("public_metrics", {})
+            raw_date = item.get("created_at")
 
             tweets.append(
                 Tweet(
                     url=f"https://x.com/{author_handle}/status/{tweet_id}",
                     source="x.com",
-                    published_at=parse_datetime(item.get("created_at")),
+                    published_at=maybe_parse_datetime(raw_date) if raw_date else None,
                     query=query,
                     tweet_id=tweet_id,
                     author_handle=author_handle,

--- a/src/unbubble_sources/search/x.py
+++ b/src/unbubble_sources/search/x.py
@@ -8,6 +8,7 @@ from datetime import datetime
 import httpx
 
 from unbubble_sources.data import SearchQuery, Source, Tweet, Usage
+from unbubble_sources.parsers import parse_datetime
 
 X_API_URL = "https://api.twitter.com/2/tweets/search/recent"
 
@@ -135,7 +136,7 @@ class XSearcher:
                 Tweet(
                     url=f"https://x.com/{author_handle}/status/{tweet_id}",
                     source="x.com",
-                    published_at=_parse_datetime(item.get("created_at")),
+                    published_at=parse_datetime(item.get("created_at")),
                     query=query,
                     tweet_id=tweet_id,
                     author_handle=author_handle,
@@ -158,12 +159,3 @@ def _to_rfc3339(date_str: str) -> str:
     if "T" in date_str:
         return date_str
     return f"{date_str}T00:00:00Z"
-
-
-def _parse_datetime(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    try:
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
-    except ValueError:
-        return None

--- a/tests/test_gnews_searcher.py
+++ b/tests/test_gnews_searcher.py
@@ -232,3 +232,4 @@ def test_article_dataclass() -> None:
     )
     assert article.title == "Test Article"
     assert article.query == query
+    

--- a/tests/test_gnews_searcher.py
+++ b/tests/test_gnews_searcher.py
@@ -2,6 +2,7 @@
 
 from typing import Any
 from unittest.mock import MagicMock
+from datetime import datetime, timezone
 
 import httpx
 import pytest
@@ -225,7 +226,7 @@ def test_article_dataclass() -> None:
         title="Test Article",
         url="https://example.com",
         source="Test Source",
-        published_at="2026-02-01",
+        published_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
         description="Test description",
         query=query,
     )

--- a/tests/test_gnews_searcher.py
+++ b/tests/test_gnews_searcher.py
@@ -1,8 +1,8 @@
 """Tests for GNewsSearcher."""
 
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import MagicMock
-from datetime import datetime, timezone
 
 import httpx
 import pytest
@@ -226,10 +226,9 @@ def test_article_dataclass() -> None:
         title="Test Article",
         url="https://example.com",
         source="Test Source",
-        published_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        published_at=datetime(2026, 2, 1, tzinfo=UTC),
         description="Test description",
         query=query,
     )
     assert article.title == "Test Article"
     assert article.query == query
-    


### PR DESCRIPTION
## What

Changes `published_at` from `str | None` to `datetime | None` in the `Source` model and all searchers.

## Why

The field was inconsistent across sources — some returned ISO timestamps, others relative strings like "3 days ago" — making it unusable for filtering and sorting.

## How

Each searcher now parses the raw string into a `datetime` via a small `_parse_datetime` helper. If parsing fails (e.g. Claude's `page_age` which is always relative), it falls back to `None`.

The JSON serializer in `run.py` was updated to emit proper ISO 8601 strings, and the frontend formats them as readable dates.

## Notes

Existing data with string `published_at` values will show as `null` going forward. Backfilling is possible if needed.