### PR TITLE
Improve documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,637 @@
-MIT License
+Unbubble Sources
+Copyright (C) 2026 Unbubble Contributors
 
-Copyright (c) 2026 Unbubble Contributors
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+--------------------------------------------------------------------------------
+
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Unbubble Sources takes a news event as input and returns sources (news articles,
 
 ```bash
 # Install (base — no ML dependencies)
-git clone https://github.com/your-org/unbubble.git
-cd unbubble/sources
+git clone https://github.com/UnbubbleHub/sources.git
+cd sources
 uv sync
 
 # Install with ML extras (required for PCAAggregator / type: pca)
@@ -321,9 +321,17 @@ Vercel picks up `requirements.txt` (or `pyproject.toml` with `[project].dependen
 
 ## Contributing
 
-1. Fork, branch, make changes, add tests
-2. `uv run pytest -v && uv run ruff check . && uv run mypy src/`
-3. Open a PR
+See [`docs/CONTRIBUTING.md`](docs/CONTRIBUTING.md) for project values,
+the pull-request loop, coding conventions, and a worked example for
+adding a new component.
+
+Short version:
+
+1. Open an issue describing what you want to do (for anything beyond a
+   one-line fix).
+2. Fork, branch from `main`, make changes, add tests.
+3. `uv run ruff check . && uv run mypy src/ && uv run pytest -v`
+4. Open a PR with a clear description of the change.
 
 ### Ideas
 
@@ -333,4 +341,7 @@ Vercel picks up `requirements.txt` (or `pyproject.toml` with `[project].dependen
 
 ## License
 
-MIT License -- Copyright (c) 2026 Unbubble Contributors
+Unbubble Sources is released under the
+[GNU Affero General Public License v3.0 or later](LICENSE) (AGPL-3.0-or-later).
+
+Copyright (C) 2026 Unbubble Contributors.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,10 +39,6 @@ in mind when proposing changes:
   config + inputs. Avoid hidden state. When you cache, cache transparently.
   When you call an LLM, log the prompt and the parsed result.
 
-These aren't slogans — they map directly onto reviewer questions. If a PR
-makes the meta-level *less* visible (more hardcoded weights, less
-configurable axes, hidden filtering), reviewers will push back.
-
 ---
 
 ## Ways to contribute
@@ -135,25 +131,8 @@ A few notes:
 ## Coding conventions
 
 - **Type-annotate everything.** `mypy --strict` must pass.
-- **Imports at the top of the file**, ordered stdlib → third-party →
-  `unbubble_sources.*`. Enforced by ruff/isort. Lazy imports are reserved
-  for optional ML dependencies (see `aggregator/embeddings.py` for the
-  pattern).
-- **Frozen dataclasses** for core data types (in `data/models.py`). `Usage`
-  is the deliberate exception — it accumulates.
-- **Pydantic models** for configuration. Discriminated unions via
-  `type: Literal[...]` + `Field(discriminator="type")`.
-- **Protocol-based interfaces** for every pipeline stage
-  (`QueryGenerator`, `SourceSearcher`, `SourceAnnotator`, `SourceRanker`,
-  `QueryAggregator`). Implementations satisfy the protocol structurally.
-- **Async everywhere I/O happens.** Concurrency via `asyncio.gather`.
-- **No `print()` in library code.** Use `logging.getLogger(__name__)`.
-  `main.py` is the only place that may write to stdout.
-- **Individual searcher / generator failures are logged and skipped**, not
-  raised. One failing backend should not abort a whole run.
-- **No new hardcoded weights or thresholds in code.** If you need a
-  knob, make it a config field. If the behaviour reflects a design
-  decision, document it in code *and* in the README.
+- **Use ruff for typing linting.**
+- **Follogoogle coding styledguides where possible.** See [here](https://google.github.io/styleguide/pyguide.html)
 
 ### Adding a new component
 
@@ -165,34 +144,11 @@ annotator, or ranker:
 2. Add a Pydantic config model in `src/unbubble_sources/config/models.py`
    with a `type: Literal[...]` discriminator, and extend the union type.
 3. Add the instantiation branch in `src/unbubble_sources/config/factory.py`.
-4. Export the class from `src/unbubble_sources/__init__.py` and add it to
-   `__all__`. If the class has heavy or optional dependencies, use the
-   lazy-import path (`__getattr__`) instead of a direct import.
-5. Add tests under `tests/test_<name>.py`. Mock the API boundary; do not
-   make real network calls.
-6. Add an example YAML config under `configs/` if it exercises a new
+4. Add tests under `tests/test_<name>.py`.
+5. Add an example YAML config under `configs/` if it exercises a new
    capability.
-7. Update the README's environment variables, config, and capabilities
+6. Update the README's environment variables, config, and capabilities
    tables.
-
-A concrete worked example for adding a search backend:
-
-1. Create `src/unbubble_sources/search/mybackend.py` with a class that
-   implements the `SourceSearcher` protocol from
-   `src/unbubble_sources/search/base.py`.
-2. Add a `MyBackendSearcherConfig` Pydantic model to
-   `src/unbubble_sources/config/models.py` with
-   `type: Literal["mybackend"]`, and extend the `SearcherConfig`
-   discriminated union.
-3. Add the instantiation branch in
-   `src/unbubble_sources/config/factory.py` (inside `create_searcher`).
-4. Export the class from `src/unbubble_sources/__init__.py` and add it to
-   `__all__`. If the class pulls in an optional SDK, use the
-   lazy-import path (`__getattr__` at the bottom of `__init__.py`).
-5. Add `configs/with_mybackend.yaml` exercising the new searcher.
-6. Add `tests/test_mybackend_searcher.py`, mocking the SDK at its boundary.
-7. Update `README.md` with the new environment variable and a row in the
-   searcher table.
 
 ---
 
@@ -205,30 +161,6 @@ uv run pytest -v
 uv run mypy src/
 uv run ruff check .
 ```
-
-Conventions:
-
-- Tests are standalone `def test_*` functions, not classes.
-- Use module-level `@pytest.fixture` for shared setup.
-- `pytest-asyncio` is configured in `auto` mode — `async def test_*`
-  works directly.
-- Mock external APIs at the SDK boundary (e.g. `anthropic.AsyncAnthropic`),
-  not at HTTP.
-- One test file per source module under `tests/`, mirroring the package
-  layout.
-
----
-
-## Working with API keys and secrets
-
-Do not commit `.env` files, real API keys, or sample run logs that contain
-secrets. The repo's `.gitignore` covers the standard cases, but please
-double-check any new fixture files. If you suspect a key has been leaked,
-revoke and rotate it immediately, then notify the maintainers privately
-(do **not** open a public issue — that amplifies the leak).
-
-The `livedemo/` subproject talks to the library through an HTTP boundary
-and has its own auth conventions documented in `livedemo/AGENTS.md`.
 
 ---
 
@@ -263,18 +195,6 @@ declared in `[project.optional-dependencies]` and lazy-imported. Today the
 
 If you find an existing hard dependency that should be optional, that's a
 welcome bug report or PR.
-
----
-
-## Roadmap pointers
-
-If you're looking for a place to contribute, the README's "Roadmap" and
-"Ideas" sections are a good start. Larger architectural changes currently
-in design — a `Scorer` / `Metric` protocol pair, a `RunResult` wrapper,
-deterministic URL-based article-genre annotation, a political-compass
-metric, an evaluation harness — will land as separate issues with linked
-design notes. If any of those sound interesting, please reach out before
-starting work so we can avoid stepping on each other.
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,289 @@
+# Contributing to Unbubble Sources
+
+Thanks for considering a contribution. Unbubble Sources is part of [Unbubble
+Hub](https://unbubblehub.org), an open research initiative for tools that
+fight social polarization. The project is small, friendly, and explicitly
+research-oriented — most contributions land through conversation as much as
+through code.
+
+This document is the **external-facing** guide: it covers what the project
+values, how to get involved, the pull-request loop, and the conventions a
+contribution should respect. If anything below is unclear, opening an issue
+is itself a useful contribution.
+
+---
+
+## What the project is trying to do
+
+Sources is for **substantively contested questions** — questions where
+reasonable people, looking at the same evidence, legitimately arrive at
+different positions because they weigh different considerations (industrial
+policy, energy strategy, immigration, taxation, foreign policy, …). For
+these questions the goal is *not* to surface a "correct" answer but to make
+the **space of substantive positions partially visible** so a reader can form
+their own judgment with awareness of what they would otherwise miss.
+
+This shapes design choices throughout the codebase. Three principles to keep
+in mind when proposing changes:
+
+- **Transparency over cleverness.** Every annotation, score, and ranking
+  decision should be inspectable. If a choice (a weight, a threshold, a
+  prompt) is buried inside code, future contributors and users cannot
+  contest it. Prefer YAML-configurable parameters and explicit provenance
+  over hidden defaults.
+- **Plurality over correctness.** The system tries to span the range of
+  legitimate positions rather than identify the "right" one. Be cautious
+  with features that filter, suppress, or rank-down whole classes of
+  sources.
+- **Open, auditable, reproducible.** Outputs should be reproducible from
+  config + inputs. Avoid hidden state. When you cache, cache transparently.
+  When you call an LLM, log the prompt and the parsed result.
+
+These aren't slogans — they map directly onto reviewer questions. If a PR
+makes the meta-level *less* visible (more hardcoded weights, less
+configurable axes, hidden filtering), reviewers will push back.
+
+---
+
+## Ways to contribute
+There
+is room for contributions of many kinds:
+
+- **Code** — new searchers, query generators, annotators, scorers, metrics,
+  rankers, tests, bug fixes, performance work, doc improvements.
+- **Datasets** — hand-labeled ground-truth fixtures for evaluation (we will
+  need these for the metrics work and the paper). A few dozen labeled
+  sources for one or two contested topics is genuinely useful.
+- **Research notes** — write up an analysis of how the pipeline performs on
+  a topic you know well; surface where it gets things right or wrong.
+- **Translations and locale calibration** — the annotation prompts and (in
+  future) URL-genre heuristics behave differently across journalistic
+  cultures. Native speakers of Italian, Spanish, French, German, and others
+  are valuable here.
+- **Issues and feedback** — opening a well-described issue, even without a
+  fix, is a real contribution.
+
+If you're not sure where to start, open an issue describing what you'd like
+to work on, or reach out via the channels on the [Unbubble Hub
+homepage](https://unbubblehub.org).
+
+---
+
+## Getting set up
+
+Detailed setup is in the [README](../README.md). The short version:
+
+```bash
+git clone https://github.com/UnbubbleHub/sources.git
+cd sources
+uv sync --all-extras   # base + ml + dev
+export CLAUDE_API_KEY=...
+uv run pytest -v
+uv run python main.py "Climate summit negotiations"
+```
+
+Python 3.11+ is required. The project uses [uv](https://github.com/astral-sh/uv)
+as its package manager.
+
+A few notes:
+
+- The default config uses `PCAAggregator`, which depends on
+  `sentence-transformers` and `torch`. Without the `ml` extras, use a
+  config that sets `aggregator: {type: noop}` or use `claude_e2e.yaml`.
+- The `[dev]` extras include `pytest`, `mypy`, `ruff` — needed for the CI
+  checks described below.
+- Tests do not make real network calls. If you add a test that requires
+  one, mock the API boundary instead.
+
+---
+
+## The pull-request loop
+
+1. **Open an issue first** for anything more than a one-line fix. This is
+   how we coordinate and avoid duplicated work. Describe what you intend
+   to do, ideally with a sketch of the design. Maintainers will respond
+   quickly with thoughts or questions.
+2. **Fork and branch.** Branch from `main`. Use a short, descriptive name;
+   prefixing with your initials is conventional in this repo
+   (e.g. `lc/exa-search`, `dlb/genre-annotator`).
+3. **Keep PRs focused.** One concern per PR. A refactor and a new feature
+   should be two PRs. Smaller PRs get reviewed faster and merged with less
+   friction.
+4. **Run the dev checks locally before pushing:**
+
+   ```bash
+   uv run ruff check .
+   uv run ruff format .
+   uv run mypy src/
+   uv run pytest -v
+   ```
+
+   CI runs the same three checks (`ruff check`, `mypy src/`, `pytest -v`)
+   and will block a merge if any fail.
+5. **Update documentation.** If you changed behaviour visible to users,
+   update the `README.md`. If you added a contributor-facing process or a
+   new convention, update this file.
+6. **Open the PR** against `main` with a clear title and a description
+   that explains the *why*, not just the *what*. Link the issue. List any
+   follow-ups you're deliberately deferring.
+7. **Address review comments.** Reviewers may push back on the design
+   itself, not just the implementation — that's expected, and welcome. If
+   a discussion gets long, consider splitting the PR.
+
+---
+
+## Coding conventions
+
+- **Type-annotate everything.** `mypy --strict` must pass.
+- **Imports at the top of the file**, ordered stdlib → third-party →
+  `unbubble_sources.*`. Enforced by ruff/isort. Lazy imports are reserved
+  for optional ML dependencies (see `aggregator/embeddings.py` for the
+  pattern).
+- **Frozen dataclasses** for core data types (in `data/models.py`). `Usage`
+  is the deliberate exception — it accumulates.
+- **Pydantic models** for configuration. Discriminated unions via
+  `type: Literal[...]` + `Field(discriminator="type")`.
+- **Protocol-based interfaces** for every pipeline stage
+  (`QueryGenerator`, `SourceSearcher`, `SourceAnnotator`, `SourceRanker`,
+  `QueryAggregator`). Implementations satisfy the protocol structurally.
+- **Async everywhere I/O happens.** Concurrency via `asyncio.gather`.
+- **No `print()` in library code.** Use `logging.getLogger(__name__)`.
+  `main.py` is the only place that may write to stdout.
+- **Individual searcher / generator failures are logged and skipped**, not
+  raised. One failing backend should not abort a whole run.
+- **No new hardcoded weights or thresholds in code.** If you need a
+  knob, make it a config field. If the behaviour reflects a design
+  decision, document it in code *and* in the README.
+
+### Adding a new component
+
+The pattern is the same for any new searcher, generator, aggregator,
+annotator, or ranker:
+
+1. Implement the corresponding `Protocol` from `<package>/base.py` in a
+   new file under `src/unbubble_sources/<package>/`.
+2. Add a Pydantic config model in `src/unbubble_sources/config/models.py`
+   with a `type: Literal[...]` discriminator, and extend the union type.
+3. Add the instantiation branch in `src/unbubble_sources/config/factory.py`.
+4. Export the class from `src/unbubble_sources/__init__.py` and add it to
+   `__all__`. If the class has heavy or optional dependencies, use the
+   lazy-import path (`__getattr__`) instead of a direct import.
+5. Add tests under `tests/test_<name>.py`. Mock the API boundary; do not
+   make real network calls.
+6. Add an example YAML config under `configs/` if it exercises a new
+   capability.
+7. Update the README's environment variables, config, and capabilities
+   tables.
+
+A concrete worked example for adding a search backend:
+
+1. Create `src/unbubble_sources/search/mybackend.py` with a class that
+   implements the `SourceSearcher` protocol from
+   `src/unbubble_sources/search/base.py`.
+2. Add a `MyBackendSearcherConfig` Pydantic model to
+   `src/unbubble_sources/config/models.py` with
+   `type: Literal["mybackend"]`, and extend the `SearcherConfig`
+   discriminated union.
+3. Add the instantiation branch in
+   `src/unbubble_sources/config/factory.py` (inside `create_searcher`).
+4. Export the class from `src/unbubble_sources/__init__.py` and add it to
+   `__all__`. If the class pulls in an optional SDK, use the
+   lazy-import path (`__getattr__` at the bottom of `__init__.py`).
+5. Add `configs/with_mybackend.yaml` exercising the new searcher.
+6. Add `tests/test_mybackend_searcher.py`, mocking the SDK at its boundary.
+7. Update `README.md` with the new environment variable and a row in the
+   searcher table.
+
+---
+
+## Tests, types, lint
+
+All three must pass before a PR is mergeable:
+
+```bash
+uv run pytest -v
+uv run mypy src/
+uv run ruff check .
+```
+
+Conventions:
+
+- Tests are standalone `def test_*` functions, not classes.
+- Use module-level `@pytest.fixture` for shared setup.
+- `pytest-asyncio` is configured in `auto` mode — `async def test_*`
+  works directly.
+- Mock external APIs at the SDK boundary (e.g. `anthropic.AsyncAnthropic`),
+  not at HTTP.
+- One test file per source module under `tests/`, mirroring the package
+  layout.
+
+---
+
+## Working with API keys and secrets
+
+Do not commit `.env` files, real API keys, or sample run logs that contain
+secrets. The repo's `.gitignore` covers the standard cases, but please
+double-check any new fixture files. If you suspect a key has been leaked,
+revoke and rotate it immediately, then notify the maintainers privately
+(do **not** open a public issue — that amplifies the leak).
+
+The `livedemo/` subproject talks to the library through an HTTP boundary
+and has its own auth conventions documented in `livedemo/AGENTS.md`.
+
+---
+
+## Licensing
+
+Unbubble Sources is licensed under the
+[GNU Affero General Public License v3.0 or later](../LICENSE)
+(AGPL-3.0-or-later), in line with the Unbubble Hub policy that
+information-integrity tools should be open, transparent, and accessible.
+
+By contributing, you agree that your contributions will be licensed under
+the same terms. If you embed Unbubble Sources in a network-accessible
+service, the AGPL requires you to make the source of your modified
+version available to users of that service — read the
+[LICENSE](../LICENSE) carefully if this affects your deployment plans.
+
+For substantial contributions (new components, new pipeline stages),
+maintainers may ask you to add yourself to a `CONTRIBUTORS` file or to be
+credited in the academic paper depending on the nature of the work.
+
+---
+
+## A note on dependencies
+
+The base install must stay lightweight (so Sources can run in serverless
+environments like Vercel Python functions, which cap bundles at 500 MB
+uncompressed). Heavy or optional dependencies — `torch`,
+`sentence-transformers`, `transformers`, large model artifacts — must be
+declared in `[project.optional-dependencies]` and lazy-imported. Today the
+`ml` extra holds the PCA-aggregator dependencies; future extras (`evaluate`,
+`local-llm`, …) should follow the same pattern.
+
+If you find an existing hard dependency that should be optional, that's a
+welcome bug report or PR.
+
+---
+
+## Roadmap pointers
+
+If you're looking for a place to contribute, the README's "Roadmap" and
+"Ideas" sections are a good start. Larger architectural changes currently
+in design — a `Scorer` / `Metric` protocol pair, a `RunResult` wrapper,
+deterministic URL-based article-genre annotation, a political-compass
+metric, an evaluation harness — will land as separate issues with linked
+design notes. If any of those sound interesting, please reach out before
+starting work so we can avoid stepping on each other.
+
+---
+
+## Where to ask questions
+
+- GitHub issues for code, bugs, and feature discussions.
+- The links on the [Unbubble Hub homepage](https://unbubblehub.org) for
+  broader project conversations.
+- The [Substack](https://unbubblehub.substack.com) for project updates and
+  research notes.
+
+Thanks for being here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Open tools for research and applications against social polarization"
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = { text = "AGPL-3.0-or-later" }
 authors = [
     { name = "Unbubble Contributors" },
 ]
@@ -21,7 +21,7 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
- Add `docs/CONTRIBUTING.md` with project values, PR loop, coding
  conventions, and a worked example for adding a search backend.
- Relicense from MIT to **AGPL-3.0-or-later** to align with the
  Unbubble Hub policy: replaces `LICENSE`, updates `pyproject.toml`
  (`license` field + OSI classifier), and the `README` license section.
- Fix the README clone URL (`your-org/unbubble` → `UnbubbleHub/sources`)
  and point the README's Contributing section at the new doc.